### PR TITLE
v4xx: wcnss_service: Use new AOSP label for misc.

### DIFF
--- a/sepolicy/wcnss_service.te
+++ b/sepolicy/wcnss_service.te
@@ -1,5 +1,5 @@
 allow wcnss_service self:capability { chown fowner };
 
 allow wcnss_service block_device:dir search;
-allow wcnss_service misc_partition:blk_file r_file_perms;
+allow wcnss_service misc_block_device:blk_file r_file_perms;
 #allow wcnss_service mmc_block_device:dir search;


### PR DESCRIPTION
misc_partition is deprecated in Nougat and has its
own label in system/sepolicy, use this label.

Change-Id: I4f8977bfa23ef14ad9bc8a628d20e609af32abe3
Signed-off-by: Adam Myczkowski mycaxd511@gmail.com
